### PR TITLE
Add 5xx retry handling to Do method

### DIFF
--- a/client.go
+++ b/client.go
@@ -465,7 +465,7 @@ func (c *Client) Do(ctx context.Context, method string, path string, queryParams
 			return nil, err
 		}
 		return c.Do(ctx, method, path, queryParams, input, output, append(retry, stat)...)
-	case http.StatusTooManyRequests:
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		// Sleep for a bit and try again.
 		// TODO(shinmog): When/if this is implemented, verify backoff logic with eng.
 		time.Sleep(time.Duration(len(retry)+1) * time.Second)

--- a/client.go
+++ b/client.go
@@ -76,6 +76,8 @@ type Client struct {
 	testData        []*http.Response
 	testIndex       int
 	authFileContent []byte
+
+	sleep func(time.Duration) // Sleep function to override in tests.
 }
 
 // Setup configures the HttpClient param according to the combination of locally
@@ -237,6 +239,11 @@ func (c *Client) Setup() error {
 		c.apiPrefix = fmt.Sprintf("%s://%s:%d", c.Protocol, c.Host, c.Port)
 	} else {
 		c.apiPrefix = fmt.Sprintf("%s://%s", c.Protocol, c.Host)
+	}
+
+	// Sleep function.
+	if c.sleep == nil {
+		c.sleep = time.Sleep
 	}
 
 	return nil
@@ -468,7 +475,7 @@ func (c *Client) Do(ctx context.Context, method string, path string, queryParams
 	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		// Sleep for a bit and try again.
 		// TODO(shinmog): When/if this is implemented, verify backoff logic with eng.
-		time.Sleep(time.Duration(len(retry)+1) * time.Second)
+		c.sleep(time.Duration(len(retry)+1) * time.Second)
 		return c.Do(ctx, method, path, queryParams, input, output, append(retry, stat)...)
 	default:
 		return body, stat


### PR DESCRIPTION
## Description

Closes #1

<!--- Describe your changes in detail -->

## Motivation and Context

Currently 5xx errors aren't retried. Adding to improve user experience and handling according to PaloAlto [documentation](https://pan.dev/prisma-cloud/api/cspm/api-errors/#reattempting-requests-that-fail-due-to-a-server-error).

## How Has This Been Tested?

Added a test to client_test.go to verify retry for 5xx errors.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
